### PR TITLE
Rename Duration and Frequency type enums and classes

### DIFF
--- a/core/constants/index.ts
+++ b/core/constants/index.ts
@@ -432,7 +432,7 @@ export enum CARE_PHASE_DURATION_TYPE {
 /**
  * @version v0.0.1-next
  */
-export enum TREATMENT_DURATION_TYPE {
+export enum DURATION_TYPE {
   DAYS = "days",
   HOURS = "hours",
   WHILE_IN_PHASE = "while_in_phase",
@@ -453,7 +453,7 @@ export enum MONITORING_VALUE_SOURCE {
   CALCULATED = "calculated_monitoring_value", // Intégrer pour pouvoir distinguer les monitorings values calculables a partie d'autre source de donnée . ex.: Pourcentage de variation d'un monitoring value sur une periods donnée et on pourra aussi fournir la formule de calcule et les variables independantes
   NOT_CALCULATED = "not_calculated_monitoring_value",
 }
-export enum MONITORING_FREQUENCY_TYPE {
+export enum FREQUENCY_TYPE {
   DAILY = "day",
   HOURSLY = "hours",
   WEEKLY = "week",

--- a/core/nutrition_care/domain/modules/carePhase/models/entities/MonitoringElement.ts
+++ b/core/nutrition_care/domain/modules/carePhase/models/entities/MonitoringElement.ts
@@ -16,7 +16,7 @@ import {
   SystemCode,
 } from "@/core/shared";
 import { ValueOf } from "@/utils";
-import { IMonitoringFrequency, MonitoringFrequency } from "../valueObjects";
+import { IFrequency, Frequency, Duration, IDuration } from "../valueObjects";
 export type MONITORING_CODE_TYPE =
   | AnthroSystemCodes
   | ValueOf<typeof BIOCHEMICAL_REF_CODES>
@@ -26,14 +26,16 @@ export interface IMonitoringElement extends EntityPropsBaseType {
   category: MONITORING_ELEMENT_CATEGORY;
   source: MONITORING_VALUE_SOURCE;
   code: SystemCode<MONITORING_CODE_TYPE>;
-  frequency: MonitoringFrequency;
+  frequency: Frequency;
+  duration: Duration;
 }
 
 export interface CreateMonitoringElement {
   category: MONITORING_ELEMENT_CATEGORY;
   source: MONITORING_VALUE_SOURCE;
   code: MONITORING_CODE_TYPE;
-  frequency: IMonitoringFrequency;
+  frequency: IFrequency;
+  duration: IDuration;
 }
 
 export class MonitoringElement extends Entity<IMonitoringElement> {
@@ -46,8 +48,11 @@ export class MonitoringElement extends Entity<IMonitoringElement> {
   getCode(): MONITORING_CODE_TYPE {
     return this.props.code.unpack();
   }
-  getFrequency(): IMonitoringFrequency {
+  getFrequency(): IFrequency {
     return this.props.frequency.unpack();
+  }
+  getDuration(): IDuration {
+    return this.props.duration.unpack();
   }
   // BETA: laisser les methods d'update d'abord...
   validate(): void {
@@ -60,9 +65,10 @@ export class MonitoringElement extends Entity<IMonitoringElement> {
     id: AggregateID
   ): Result<MonitoringElement> {
     try {
-      const frequencyRes = MonitoringFrequency.create(createProps.frequency);
+      const frequencyRes = Frequency.create(createProps.frequency);
+      const durationRes = Duration.create(createProps.duration);
       const codeRes = SystemCode.create(createProps.code);
-      const combinedRes = Result.combine([codeRes, frequencyRes]);
+      const combinedRes = Result.combine([codeRes, frequencyRes, durationRes]);
       if (combinedRes.isFailure) {
         return Result.fail(formatError(combinedRes, MonitoringElement.name));
       }
@@ -73,6 +79,7 @@ export class MonitoringElement extends Entity<IMonitoringElement> {
             category: createProps.category,
             code: codeRes.val,
             frequency: frequencyRes.val,
+            duration: durationRes.val,
             source: createProps.source,
           },
         })

--- a/core/nutrition_care/domain/modules/carePhase/models/entities/RecommendedTreatment.ts
+++ b/core/nutrition_care/domain/modules/carePhase/models/entities/RecommendedTreatment.ts
@@ -18,10 +18,12 @@ import {
 import { MilkType } from "../../../milk";
 import {
   CreateTreatmentTrigger,
-  ITreatmentDuration,
+  Duration,
   ITreatmentTrigger,
-  TreatmentDuration,
+  IDuration,
   TreatmentTrigger,
+  Frequency,
+  IFrequency,
 } from "../valueObjects";
 import { ValueOf } from "@/utils";
 
@@ -30,7 +32,8 @@ export interface IRecommendedTreatment extends EntityPropsBaseType {
   applicabilyCondition: Criterion;
   type: RECOMMENDED_TREATMENT_TYPE;
   treatmentCode: SystemCode<MilkType | MEDICINE_CODES>;
-  duration: TreatmentDuration;
+  duration: Duration;
+  frequency: Frequency;
   triggers: {
     onStart: TreatmentTrigger[];
     onEnd: TreatmentTrigger[];
@@ -42,7 +45,8 @@ export interface CreateRecommededTreatment {
   applicabilyCondition: CreateCriterion;
   type: RECOMMENDED_TREATMENT_TYPE;
   treatmentCode: MilkType | MEDICINE_CODES;
-  duration: ITreatmentDuration;
+  duration: IDuration;
+  frequency: IFrequency;
   triggers: {
     onStart: CreateTreatmentTrigger[];
     onEnd: CreateTreatmentTrigger[];
@@ -62,8 +66,11 @@ export class RecommendedTreatment extends Entity<IRecommendedTreatment> {
   getTreatmentCode(): MilkType | MEDICINE_CODES {
     return this.props.treatmentCode.unpack();
   }
-  getDuration(): ITreatmentDuration {
+  getDuration(): IDuration {
     return this.props.duration.unpack();
+  }
+  getFrequency(): IFrequency {
+    return this.props.frequency.unpack();
   }
   getStartedTriggers(): ITreatmentTrigger[] {
     return this.props.triggers.onStart.map(trigger => trigger.unpack());
@@ -88,20 +95,21 @@ export class RecommendedTreatment extends Entity<IRecommendedTreatment> {
       const codeRes = SystemCode.create(createProps.code);
       const treatmentCodeRes = SystemCode.create(createProps.treatmentCode);
       const criterionRes = Criterion.create(createProps.applicabilyCondition);
-      const treatmentDurationRes = TreatmentDuration.create(
-        createProps.duration
-      );
+      const treatmentDurationRes = Duration.create(createProps.duration);
+      const frequencyRes = Frequency.create(createProps.frequency);
       const onStartTriggersRes = createProps.triggers.onStart.map(trigger =>
         TreatmentTrigger.create(trigger)
       );
       const onEndTriggersRes = createProps.triggers.onEnd.map(trigger =>
         TreatmentTrigger.create(trigger)
       );
+
       const combinedRes = Result.combine([
         codeRes,
         treatmentCodeRes,
         criterionRes,
         treatmentDurationRes,
+        frequencyRes,
         ...onStartTriggersRes,
         ...onEndTriggersRes,
       ]);
@@ -115,6 +123,7 @@ export class RecommendedTreatment extends Entity<IRecommendedTreatment> {
           code: codeRes.val,
           treatmentCode: treatmentCodeRes.val,
           duration: treatmentDurationRes.val,
+          frequency: frequencyRes.val,
           type: createProps.type,
           triggers: {
             onStart: onStartTriggersRes.map(trigger => trigger.val),

--- a/core/nutrition_care/domain/modules/carePhase/models/valueObjects/MonitoringFrequency.ts
+++ b/core/nutrition_care/domain/modules/carePhase/models/valueObjects/MonitoringFrequency.ts
@@ -1,4 +1,4 @@
-import { MONITORING_FREQUENCY_TYPE } from "@/core/constants";
+import { FREQUENCY_TYPE } from "@/core/constants";
 import {
   Guard,
   handleError,
@@ -7,13 +7,13 @@ import {
   ValueObject,
 } from "@/core/shared";
 
-export interface IMonitoringFrequency {
-  intervalUnit: MONITORING_FREQUENCY_TYPE;
+export interface IFrequency {
+  intervalUnit: FREQUENCY_TYPE;
   intervalValue: number;
   countInUnit: number;
 }
-export class MonitoringFrequency extends ValueObject<IMonitoringFrequency> {
-  getUnit(): MONITORING_FREQUENCY_TYPE {
+export class Frequency extends ValueObject<IFrequency> {
+  getUnit(): FREQUENCY_TYPE {
     return this.props.intervalUnit;
   }
   getIntervalValue(): number {
@@ -22,7 +22,7 @@ export class MonitoringFrequency extends ValueObject<IMonitoringFrequency> {
   getCountInUnit(): number {
     return this.props.countInUnit;
   }
-  protected validate(props: Readonly<IMonitoringFrequency>): void {
+  protected validate(props: Readonly<IFrequency>): void {
     if (
       Guard.isNegative(props.countInUnit).succeeded ||
       Guard.isNegative(props.intervalValue).succeeded
@@ -32,9 +32,9 @@ export class MonitoringFrequency extends ValueObject<IMonitoringFrequency> {
       );
     }
   }
-  static create(props: IMonitoringFrequency): Result<MonitoringFrequency> {
+  static create(props: IFrequency): Result<Frequency> {
     try {
-      return Result.ok(new MonitoringFrequency(props));
+      return Result.ok(new Frequency(props));
     } catch (e: unknown) {
       return handleError(e);
     }

--- a/core/nutrition_care/domain/modules/carePhase/models/valueObjects/TreatmentDuration.ts
+++ b/core/nutrition_care/domain/modules/carePhase/models/valueObjects/TreatmentDuration.ts
@@ -1,4 +1,4 @@
-import { TREATMENT_DURATION_TYPE } from "@/core/constants";
+import { DURATION_TYPE } from "@/core/constants";
 import {
   Guard,
   handleError,
@@ -7,34 +7,34 @@ import {
   ValueObject,
 } from "@/core/shared";
 
-export interface ITreatmentDuration {
+export interface IDuration {
   /**
    * 'days': Le traitement dure un nombre de jours défini.
    * 'hours': Le traitement dure un nombre d'heures défini.
    * 'while_in_phase': Le traitement est actif tant que le patient est dans cette phase.
    */
-  type: TREATMENT_DURATION_TYPE;
+  type: DURATION_TYPE;
   /** La valeur numérique de la durée (ex: 5 pour 5 jours). */
   value?: number;
 }
 
-export class TreatmentDuration extends ValueObject<ITreatmentDuration> {
+export class Duration extends ValueObject<IDuration> {
   getType() {
     return this.props.type;
   }
   getValue() {
     return this.props.value;
   }
-  protected validate(props: Readonly<ITreatmentDuration>): void {
+  protected validate(props: Readonly<IDuration>): void {
     if (props.value && Guard.isNegative(props.value).succeeded) {
       throw new NegativeValueError(
         "The value props on treatment duration can't be negative if it provided."
       );
     }
   }
-  static create(props: ITreatmentDuration): Result<TreatmentDuration> {
+  static create(props: IDuration): Result<Duration> {
     try {
-      return Result.ok(new TreatmentDuration(props));
+      return Result.ok(new Duration(props));
     } catch (e: unknown) {
       return handleError(e);
     }


### PR DESCRIPTION
The refactoring generalizes TreatmentDuration and MonitoringFrequency into shared Duration and Frequency value objects used across monitoring and treatments.