### PR TITLE
feat(nutrition-care): implement next/medicines use cases

### DIFF
--- a/core/nutrition_care/application/dtos/index.ts
+++ b/core/nutrition_care/application/dtos/index.ts
@@ -1,5 +1,6 @@
 export * from "./appetiteTest";
 export * from "./complication";
+export * as NextMedicinesDto from "./next/medicines";
 export * from "./core";
 export * from "./medicine";
 export * from "./milk";

--- a/core/nutrition_care/application/dtos/next/index.ts
+++ b/core/nutrition_care/application/dtos/next/index.ts
@@ -1,0 +1,1 @@
+export * from "./medicines";

--- a/core/nutrition_care/application/dtos/next/medicines/MedicationDosageResultDto.ts
+++ b/core/nutrition_care/application/dtos/next/medicines/MedicationDosageResultDto.ts
@@ -1,0 +1,10 @@
+import {
+  Amount,
+  IDosageRange,
+} from "../../../../domain/modules/next/medicines/models/valueObjects";
+
+export interface MedicationDosageResultDto {
+  dailyDosage: Amount;
+  dailyFrequency: number;
+  dosage: IDosageRange;
+}

--- a/core/nutrition_care/application/dtos/next/medicines/MedicineDto.ts
+++ b/core/nutrition_care/application/dtos/next/medicines/MedicineDto.ts
@@ -1,0 +1,22 @@
+import {
+  AdministrationRoute,
+  MEDICINE_CODES,
+  MedicineCategory,
+} from "@/core/constants";
+import { AggregateID } from "@/core/shared";
+import { IDosageCase } from "../../../../domain/modules/next/medicines/models/valueObjects";
+
+export interface MedicineDto {
+  id: AggregateID;
+  code: MEDICINE_CODES;
+  name: string;
+  category: MedicineCategory;
+  administrationRoutes: AdministrationRoute[];
+  dosageCases: IDosageCase[];
+  warnings: string[];
+  contraindications: string[];
+  interactions: string[];
+  notes: string[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/core/nutrition_care/application/dtos/next/medicines/index.ts
+++ b/core/nutrition_care/application/dtos/next/medicines/index.ts
@@ -1,0 +1,2 @@
+export * from "./MedicineDto";
+export * from "./MedicationDosageResultDto";

--- a/core/nutrition_care/application/mappers/index.ts
+++ b/core/nutrition_care/application/mappers/index.ts
@@ -7,3 +7,4 @@ export * from "./MilkMapper";
 export * from "./OrientationRefMapper";
 export * from "./PatientCareSessionMapper";
 export * from "./PatientCurrentStateMapper";
+export * as NextMedicinesMapper from "./next/medicines";

--- a/core/nutrition_care/application/mappers/next/index.ts
+++ b/core/nutrition_care/application/mappers/next/index.ts
@@ -1,0 +1,1 @@
+export * from "./medicines";

--- a/core/nutrition_care/application/mappers/next/medicines/MedicationDosageResultMapper.ts
+++ b/core/nutrition_care/application/mappers/next/medicines/MedicationDosageResultMapper.ts
@@ -1,0 +1,17 @@
+import { ApplicationMapper } from "@/core/shared";
+import { MedicationDosageResult } from "../../../../domain/modules/next/medicines/models/valueObjects";
+import { MedicationDosageResultDto } from "../../../dtos/next/medicines/MedicationDosageResultDto";
+
+export class MedicationDosageResultMapper
+  implements
+    ApplicationMapper<MedicationDosageResult, MedicationDosageResultDto>
+{
+  toResponse(entity: MedicationDosageResult): MedicationDosageResultDto {
+    const unpacked = entity.unpack();
+    return {
+      dailyDosage: unpacked.dailyDosage,
+      dailyFrequency: unpacked.dailyFrequency,
+      dosage: unpacked.dosage.unpack(),
+    };
+  }
+}

--- a/core/nutrition_care/application/mappers/next/medicines/MedicineMapper.ts
+++ b/core/nutrition_care/application/mappers/next/medicines/MedicineMapper.ts
@@ -1,0 +1,24 @@
+import { ApplicationMapper } from "@/core/shared";
+import { Medicine } from "../../../../domain/modules/next/medicines/models";
+import { MedicineDto } from "../../../dtos/next/medicines/MedicineDto";
+
+export class MedicineMapper
+  implements ApplicationMapper<Medicine, MedicineDto>
+{
+  toResponse(entity: Medicine): MedicineDto {
+    return {
+      id: entity.id,
+      code: entity.getCode(),
+      name: entity.getName(),
+      category: entity.getCategory(),
+      administrationRoutes: entity.getAdministrationRoutes(),
+      dosageCases: entity.getDosageCases(),
+      warnings: entity.getWarings(),
+      contraindications: entity.getContraIndications(),
+      interactions: entity.getInteractions(),
+      notes: entity.getNotes(),
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+    };
+  }
+}

--- a/core/nutrition_care/application/mappers/next/medicines/index.ts
+++ b/core/nutrition_care/application/mappers/next/medicines/index.ts
@@ -1,0 +1,2 @@
+export * from "./MedicineMapper";
+export * from "./MedicationDosageResultMapper";

--- a/core/nutrition_care/application/useCases/index.ts
+++ b/core/nutrition_care/application/useCases/index.ts
@@ -4,3 +4,4 @@ export * from "./core";
 export * from "./medicines";
 export * from "./milk";
 export * from "./orientations";
+export * as NextMedicinesUseCases from "./next/medicines";

--- a/core/nutrition_care/application/useCases/next/index.ts
+++ b/core/nutrition_care/application/useCases/next/index.ts
@@ -1,0 +1,1 @@
+export * from "./medicines";

--- a/core/nutrition_care/application/useCases/next/medicines/Create/Request.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/Create/Request.ts
@@ -1,0 +1,5 @@
+import { CreateMedicine } from "../../../../../domain/modules/next/medicines/models";
+
+export interface CreateMedicineRequest {
+  data: CreateMedicine;
+}

--- a/core/nutrition_care/application/useCases/next/medicines/Create/Response.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/Create/Response.ts
@@ -1,0 +1,6 @@
+import { AggregateID, Either, ExceptionBase, Result } from "@/core/shared";
+
+export type CreateMedicineResponse = Either<
+  ExceptionBase,
+  Result<{ id: AggregateID }>
+>;

--- a/core/nutrition_care/application/useCases/next/medicines/Create/UseCase.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/Create/UseCase.ts
@@ -1,0 +1,47 @@
+import {
+  GenerateUniqueId,
+  handleError,
+  left,
+  Result,
+  right,
+  UseCase,
+} from "@shared";
+import { CreateMedicineRequest } from "./Request";
+import { CreateMedicineResponse } from "./Response";
+import {
+  Medicine,
+  MedicineRepository,
+} from "../../../../../domain/modules/next/medicines/models";
+
+export class CreateMedicineUseCase
+  implements UseCase<CreateMedicineRequest, CreateMedicineResponse>
+{
+  constructor(
+    private readonly idGenerator: GenerateUniqueId,
+    private readonly repo: MedicineRepository
+  ) {}
+  async execute(
+    request: CreateMedicineRequest
+  ): Promise<CreateMedicineResponse> {
+    try {
+      const newId = this.idGenerator.generate().toValue();
+      const medicineRes = Medicine.create(request.data, newId);
+      if (medicineRes.isFailure) return left(medicineRes);
+
+      const medicine = medicineRes.val;
+      const exist = await this.repo.exist(medicine.getProps().code);
+      if (exist)
+        return left(
+          Result.fail(
+            `The medicine with this code [${medicine.getCode()}] already exist.`
+          )
+        );
+
+      medicine.created();
+      await this.repo.save(medicine);
+      return right(Result.ok({ id: newId }));
+    } catch (e: unknown) {
+      return left(handleError(e));
+    }
+  }
+}

--- a/core/nutrition_care/application/useCases/next/medicines/Create/index.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/Create/index.ts
@@ -1,0 +1,3 @@
+export * from "./Request";
+export * from "./Response";
+export * from "./UseCase";

--- a/core/nutrition_care/application/useCases/next/medicines/Get/Request.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/Get/Request.ts
@@ -1,0 +1,7 @@
+import { MEDICINE_CODES } from "@/core/constants";
+import { AggregateID } from "@/core/shared";
+
+export interface GetMedicineRequest {
+  code?: MEDICINE_CODES;
+  id?: AggregateID;
+}

--- a/core/nutrition_care/application/useCases/next/medicines/Get/Response.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/Get/Response.ts
@@ -1,0 +1,7 @@
+import { Either, ExceptionBase, Result } from "@/core/shared";
+import { MedicineDto } from "../../../../dtos/next/medicines/MedicineDto";
+
+export type GetMedicineResponse = Either<
+  ExceptionBase,
+  Result<MedicineDto[]>
+>;

--- a/core/nutrition_care/application/useCases/next/medicines/Get/UseCase.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/Get/UseCase.ts
@@ -1,0 +1,39 @@
+import {
+  ApplicationMapper,
+  handleError,
+  left,
+  right,
+  UseCase,
+} from "@shared";
+import { GetMedicineRequest } from "./Request";
+import { GetMedicineResponse } from "./Response";
+import {
+  Medicine,
+  MedicineRepository,
+} from "../../../../../domain/modules/next/medicines/models";
+import { MedicineDto } from "../../../../dtos/next/medicines/MedicineDto";
+import { SystemCode } from "@/core/shared";
+
+export class GetMedicineUseCase
+  implements UseCase<GetMedicineRequest, GetMedicineResponse>
+{
+  constructor(
+    private readonly repo: MedicineRepository,
+    private readonly mapper: ApplicationMapper<Medicine, MedicineDto>
+  ) {}
+  async execute(request: GetMedicineRequest): Promise<GetMedicineResponse> {
+    try {
+      const medicines = await (request.code
+        ? [await this.repo.getByCode(SystemCode.create(request.code).val)]
+        : request.id
+        ? [await this.repo.getById(request.id)]
+        : await this.repo.getAll());
+
+      return right(
+        Result.ok(medicines.map(medicine => this.mapper.toResponse(medicine)))
+      );
+    } catch (e: unknown) {
+      return left(handleError(e));
+    }
+  }
+}

--- a/core/nutrition_care/application/useCases/next/medicines/Get/index.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/Get/index.ts
@@ -1,0 +1,3 @@
+export * from "./Request";
+export * from "./Response";
+export * from "./UseCase";

--- a/core/nutrition_care/application/useCases/next/medicines/GetMedicineDosage/Request.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/GetMedicineDosage/Request.ts
@@ -1,0 +1,7 @@
+import { MEDICINE_CODES } from "@/core/constants";
+import { MedicationDosageContext } from "../../../../../domain/modules/next/medicines/models";
+
+export interface GetMedicineDosageRequest {
+  code: MEDICINE_CODES;
+  context: MedicationDosageContext;
+}

--- a/core/nutrition_care/application/useCases/next/medicines/GetMedicineDosage/Response.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/GetMedicineDosage/Response.ts
@@ -1,0 +1,7 @@
+import { Either, ExceptionBase, Result } from "@/core/shared";
+import { MedicationDosageResultDto } from "../../../../dtos/next/medicines/MedicationDosageResultDto";
+
+export type GetMedicineDosageResponse = Either<
+  ExceptionBase,
+  Result<MedicationDosageResultDto>
+>;

--- a/core/nutrition_care/application/useCases/next/medicines/GetMedicineDosage/UseCase.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/GetMedicineDosage/UseCase.ts
@@ -1,0 +1,41 @@
+import {
+  ApplicationMapper,
+  handleError,
+  left,
+  right,
+  UseCase,
+} from "@shared";
+import { GetMedicineDosageRequest } from "./Request";
+import { GetMedicineDosageResponse } from "./Response";
+import {
+  IMedicationDosageCalculator,
+  MedicationDosageResult,
+} from "../../../../../domain/modules/next/medicines/models";
+import { MedicationDosageResultDto } from "../../../../dtos/next/medicines/MedicationDosageResultDto";
+
+export class GetMedicineDosageUseCase
+  implements UseCase<GetMedicineDosageRequest, GetMedicineDosageResponse>
+{
+  constructor(
+    private readonly calculator: IMedicationDosageCalculator,
+    private readonly mapper: ApplicationMapper<
+      MedicationDosageResult,
+      MedicationDosageResultDto
+    >
+  ) {}
+  async execute(
+    request: GetMedicineDosageRequest
+  ): Promise<GetMedicineDosageResponse> {
+    try {
+      const dosageRes = await this.calculator.calculate(
+        request.code,
+        request.context
+      );
+      if (dosageRes.isFailure) return left(dosageRes);
+
+      return right(Result.ok(this.mapper.toResponse(dosageRes.val)));
+    } catch (e: unknown) {
+      return left(handleError(e));
+    }
+  }
+}

--- a/core/nutrition_care/application/useCases/next/medicines/GetMedicineDosage/index.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/GetMedicineDosage/index.ts
@@ -1,0 +1,3 @@
+export * from "./Request";
+export * from "./Response";
+export * from "./UseCase";

--- a/core/nutrition_care/application/useCases/next/medicines/index.ts
+++ b/core/nutrition_care/application/useCases/next/medicines/index.ts
@@ -1,0 +1,3 @@
+export * from "./Create";
+export * from "./Get";
+export * from "./GetMedicineDosage";


### PR DESCRIPTION
This commit introduces the application layer for the `next/medicines` module.

It includes:
- DTOs for `Medicine` and `MedicationDosageResult`.
- Application mappers to convert between domain entities and DTOs.
- `Create`, `Get`, and `GetMedicineDosage` use cases.
- All necessary index files with aliased exports to avoid naming conflicts.