### PR TITLE
feat(nutrition-care): implement next/medicines adapter layer

### DIFF
--- a/adapter/nutrition_care/infra/dtos/index.ts
+++ b/adapter/nutrition_care/infra/dtos/index.ts
@@ -4,3 +4,4 @@ export * from "./core";
 export * from "./medicine";
 export * from "./milk";
 export * from "./orientation";
+export * as Next from "./next";

--- a/adapter/nutrition_care/infra/dtos/next/index.ts
+++ b/adapter/nutrition_care/infra/dtos/next/index.ts
@@ -1,0 +1,1 @@
+export * from "./medicines";

--- a/adapter/nutrition_care/infra/dtos/next/medicines/MedicinePersistenceDto.ts
+++ b/adapter/nutrition_care/infra/dtos/next/medicines/MedicinePersistenceDto.ts
@@ -1,0 +1,22 @@
+import {
+  AdministrationRoute,
+  MEDICINE_CODES,
+  MedicineCategory,
+} from "@/core/constants";
+import { AggregateID } from "@/core/shared";
+import { IDosageCase } from "../../../../../core/nutrition_care/domain/modules/next/medicines/models/valueObjects";
+
+export interface MedicinePersistenceDto {
+  id: AggregateID;
+  code: MEDICINE_CODES;
+  name: string;
+  category: MedicineCategory;
+  administrationRoutes: AdministrationRoute[];
+  dosageCases: IDosageCase[];
+  warnings: string[];
+  contraindications: string[];
+  interactions: string[];
+  notes: string[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/adapter/nutrition_care/infra/dtos/next/medicines/index.ts
+++ b/adapter/nutrition_care/infra/dtos/next/medicines/index.ts
@@ -1,0 +1,1 @@
+export * from "./MedicinePersistenceDto";

--- a/adapter/nutrition_care/infra/mappers/index.ts
+++ b/adapter/nutrition_care/infra/mappers/index.ts
@@ -6,3 +6,4 @@ export * from "./MilkMapper";
 export * from "./OrientationRefMapper";
 export * from "./PatientCareSessionMapper";
 export * from "./PatientCurrentStateMapper";
+export * as Next from "./next";

--- a/adapter/nutrition_care/infra/mappers/next/index.ts
+++ b/adapter/nutrition_care/infra/mappers/next/index.ts
@@ -1,0 +1,1 @@
+export * from "./medicines";

--- a/adapter/nutrition_care/infra/mappers/next/medicines/MedicineInfraMapper.ts
+++ b/adapter/nutrition_care/infra/mappers/next/medicines/MedicineInfraMapper.ts
@@ -1,0 +1,45 @@
+import {
+  Medicine,
+  CreateMedicine,
+} from "../../../../../core/nutrition_care/domain/modules/next/medicines/models";
+import {
+  formatError,
+  InfraMapToDomainError,
+  InfrastructureMapper,
+} from "@/core/shared";
+import { MedicinePersistenceDto } from "../../dtos/next/medicines/MedicinePersistenceDto";
+
+export class MedicineInfraMapper
+  implements InfrastructureMapper<Medicine, MedicinePersistenceDto>
+{
+  toPersistence(entity: Medicine): MedicinePersistenceDto {
+    return {
+      id: entity.id,
+      code: entity.getCode(),
+      name: entity.getName(),
+      category: entity.getCategory(),
+      administrationRoutes: entity.getAdministrationRoutes(),
+      dosageCases: entity.getDosageCases(),
+      warnings: entity.getWarings(),
+      contraindications: entity.getContraIndications(),
+      interactions: entity.getInteractions(),
+      notes: entity.getNotes(),
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+    };
+  }
+  toDomain(record: MedicinePersistenceDto): Medicine {
+    const medicineRes = Medicine.create(
+      record as CreateMedicine,
+      record.id
+    );
+
+    if (medicineRes.isFailure) {
+      throw new InfraMapToDomainError(
+        formatError(medicineRes, Medicine.name)
+      );
+    }
+    const { id, createdAt, updatedAt, ...props } = medicineRes.val.getProps();
+    return new Medicine({ id, createdAt, updatedAt, props });
+  }
+}

--- a/adapter/nutrition_care/infra/mappers/next/medicines/index.ts
+++ b/adapter/nutrition_care/infra/mappers/next/medicines/index.ts
@@ -1,0 +1,1 @@
+export * from "./MedicineInfraMapper";

--- a/adapter/nutrition_care/infra/repository.expo/db/nutrition_care.schema.ts
+++ b/adapter/nutrition_care/infra/repository.expo/db/nutrition_care.schema.ts
@@ -231,3 +231,18 @@ export const patient_care_sessions = sqliteTable("patient_care_sessions", {
     enum: ["not_ready", "in_progress", "completed"],
   }).notNull(),
 });
+
+export const next_medicines = sqliteTable("next_medicines", {
+  id: text("id").primaryKey(),
+  code: text("code").notNull(),
+  name: text("name").notNull(),
+  category: text("category").notNull(),
+  administrationRoutes: text("administration_routes", { mode: "json" }).notNull(),
+  dosageCases: text("dosage_cases", { mode: "json" }).notNull(),
+  warnings: text("warnings", { mode: "json" }).notNull(),
+  contraindications: text("contraindications", { mode: "json" }).notNull(),
+  interactions: text("interactions", { mode: "json" }).notNull(),
+  notes: text("notes", { mode: "json" }).notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});

--- a/adapter/nutrition_care/infra/repository.expo/index.ts
+++ b/adapter/nutrition_care/infra/repository.expo/index.ts
@@ -5,3 +5,4 @@ export * from "./db";
 export * from "./medicines";
 export * from "./milk";
 export * from "./orientations";
+export * as Next from "./next";

--- a/adapter/nutrition_care/infra/repository.expo/next/index.ts
+++ b/adapter/nutrition_care/infra/repository.expo/next/index.ts
@@ -1,0 +1,1 @@
+export * from "./medicines";

--- a/adapter/nutrition_care/infra/repository.expo/next/medicines/MedicineRepositoryExpo.ts
+++ b/adapter/nutrition_care/infra/repository.expo/next/medicines/MedicineRepositoryExpo.ts
@@ -1,0 +1,25 @@
+import { EntityBaseRepositoryExpoWithCodeColumn } from "@/adapter/shared/repository.expo";
+import {
+  Medicine,
+  MedicineRepository,
+} from "../../../../../core/nutrition_care/domain/modules/next/medicines/models";
+import { MedicinePersistenceDto } from "../../../dtos/next/medicines/MedicinePersistenceDto";
+import { next_medicines } from "../../db/nutrition_care.schema";
+import { MedicineInfraMapper } from "../../../mappers/next/medicines/MedicineInfraMapper";
+import { ExpoSQLiteDatabase } from "drizzle-orm/expo-sqlite";
+
+export class MedicineRepositoryExpo
+  extends EntityBaseRepositoryExpoWithCodeColumn<
+    Medicine,
+    MedicinePersistenceDto,
+    typeof next_medicines
+  >
+  implements MedicineRepository
+{
+  constructor(
+    db: ExpoSQLiteDatabase<Record<string, unknown>>,
+    mapper: MedicineInfraMapper
+  ) {
+    super(db, next_medicines, mapper);
+  }
+}

--- a/adapter/nutrition_care/infra/repository.expo/next/medicines/index.ts
+++ b/adapter/nutrition_care/infra/repository.expo/next/medicines/index.ts
@@ -1,0 +1,1 @@
+export * from "./MedicineRepositoryExpo";

--- a/adapter/nutrition_care/infra/repository.web/index.ts
+++ b/adapter/nutrition_care/infra/repository.web/index.ts
@@ -4,3 +4,4 @@ export * from "./core";
 export * from "./medicines";
 export * from "./milk";
 export * from "./orientation";
+export * as Next from "./next";

--- a/adapter/nutrition_care/infra/repository.web/next/index.ts
+++ b/adapter/nutrition_care/infra/repository.web/next/index.ts
@@ -1,0 +1,1 @@
+export * from "./medicines";

--- a/adapter/nutrition_care/infra/repository.web/next/medicines/MedicineRepositoryWeb.ts
+++ b/adapter/nutrition_care/infra/repository.web/next/medicines/MedicineRepositoryWeb.ts
@@ -1,0 +1,39 @@
+import { EntityBaseRepositoryWeb } from "@/adapter/shared/repository.web";
+import {
+  Medicine,
+  MedicineRepository,
+} from "../../../../../core/nutrition_care/domain/modules/next/medicines/models";
+import { MedicinePersistenceDto } from "../../../dtos/next/medicines/MedicinePersistenceDto";
+import { SystemCode } from "@/core/shared";
+
+export class MedicineRepositoryWeb
+  extends EntityBaseRepositoryWeb<Medicine, MedicinePersistenceDto>
+  implements MedicineRepository
+{
+  protected storeName = "next_medicines";
+  async getByCode(code: SystemCode): Promise<Medicine> {
+    try {
+      const store = await this.getObjectStore();
+      return new Promise((resolve, reject) => {
+        const request = store.index("code").get(code.unpack());
+
+        request.onsuccess = event => {
+          const result = (event.target as IDBRequest).result;
+          if (!result) {
+            reject(new Error("Entity Not found"));
+            return;
+          }
+          resolve(this.mapper.toDomain(result as MedicinePersistenceDto));
+        };
+
+        request.onerror = event => {
+          console.error("Error fetching by code:", event);
+          reject(new Error("Failed to fetch entity"));
+        };
+      });
+    } catch (error) {
+      console.error(error);
+      throw new Error(error as string);
+    }
+  }
+}

--- a/adapter/nutrition_care/infra/repository.web/next/medicines/index.ts
+++ b/adapter/nutrition_care/infra/repository.web/next/medicines/index.ts
@@ -1,0 +1,1 @@
+export * from "./MedicineRepositoryWeb";

--- a/adapter/shared/repository.web/db.config.ts
+++ b/adapter/shared/repository.web/db.config.ts
@@ -1,7 +1,8 @@
 export const DB_CONFIG = {
   name: "nutrition_app_db",
-  version: 1,
+  version: 3,
   stores: {
+    next_medicines: { keyPath: "id", indexes: ["code"] },
     appetite_test_refs: { keyPath: "id", indexes: ["code"] },
     complications: { keyPath: "id", indexes: ["code"] },
     medicines: { keyPath: "id", indexes: ["code"] },

--- a/adapter/shared/repository.web/db.migrations.ts
+++ b/adapter/shared/repository.web/db.migrations.ts
@@ -12,5 +12,11 @@ export const migrations: Migration[] = [
       createStoreIndexes(db);
     },
   },
+  {
+    version: 3,
+    up: (db: IDBDatabase) => {
+      createStoreIndexes(db);
+    },
+  },
   // Futures migrations...
 ];

--- a/core/nutrition_care/application/services/index.ts
+++ b/core/nutrition_care/application/services/index.ts
@@ -5,3 +5,4 @@ export * from "./MilkService";
 export * from "./OrientationService";
 export * from "./PatientCareSessionService";
 export * from "./interfaces";
+export * as NextNutritionCareAppService from "./next";

--- a/core/nutrition_care/application/services/next/index.ts
+++ b/core/nutrition_care/application/services/next/index.ts
@@ -1,0 +1,1 @@
+export * from "./medicines";

--- a/core/nutrition_care/application/services/next/medicines/MedicineAppService.ts
+++ b/core/nutrition_care/application/services/next/medicines/MedicineAppService.ts
@@ -1,0 +1,45 @@
+import { AggregateID, AppServiceResponse, Message, UseCase } from "@shared";
+import { IMedicineAppService } from "./interfaces/IMedicineAppService";
+import {
+  CreateMedicineRequest,
+  CreateMedicineResponse,
+  GetMedicineRequest,
+  GetMedicineResponse,
+  GetMedicineDosageRequest,
+  GetMedicineDosageResponse,
+} from "../../../useCases/next/medicines";
+import { MedicineDto, MedicationDosageResultDto } from "../../../../dtos/next/medicines";
+
+export interface MedicineServiceUseCases {
+  createUC: UseCase<CreateMedicineRequest, CreateMedicineResponse>;
+  getUC: UseCase<GetMedicineRequest, GetMedicineResponse>;
+  getDosageUC: UseCase<GetMedicineDosageRequest, GetMedicineDosageResponse>;
+}
+
+export class MedicineAppService implements IMedicineAppService {
+  constructor(private readonly ucs: MedicineServiceUseCases) {}
+
+  async create(
+    req: CreateMedicineRequest
+  ): Promise<AppServiceResponse<{ id: AggregateID }> | Message> {
+    const res = await this.ucs.createUC.execute(req);
+    if (res.isRight()) return { data: res.value.val };
+    else return new Message("error", JSON.stringify((res.value as any)?.err));
+  }
+
+  async get(
+    req: GetMedicineRequest
+  ): Promise<AppServiceResponse<MedicineDto[]> | Message> {
+    const res = await this.ucs.getUC.execute(req);
+    if (res.isRight()) return { data: res.value.val };
+    else return new Message("error", JSON.stringify((res.value as any)?.err));
+  }
+
+  async getDosage(
+    req: GetMedicineDosageRequest
+  ): Promise<AppServiceResponse<MedicationDosageResultDto> | Message> {
+    const res = await this.ucs.getDosageUC.execute(req);
+    if (res.isRight()) return { data: res.value.val };
+    else return new Message("error", JSON.stringify((res.value as any)?.err));
+  }
+}

--- a/core/nutrition_care/application/services/next/medicines/index.ts
+++ b/core/nutrition_care/application/services/next/medicines/index.ts
@@ -1,0 +1,2 @@
+export * from "./MedicineAppService";
+export * from "./interfaces";

--- a/core/nutrition_care/application/services/next/medicines/interfaces/IMedicineAppService.ts
+++ b/core/nutrition_care/application/services/next/medicines/interfaces/IMedicineAppService.ts
@@ -1,0 +1,17 @@
+import { AggregateID, AppServiceResponse, Message } from "@shared";
+import {
+  CreateMedicineRequest,
+  GetMedicineRequest,
+  GetMedicineDosageRequest,
+} from "../../../../useCases/next/medicines";
+import { MedicineDto, MedicationDosageResultDto } from "../../../../../dtos/next/medicines";
+
+export interface IMedicineAppService {
+  create(
+    req: CreateMedicineRequest
+  ): Promise<AppServiceResponse<{ id: AggregateID }> | Message>;
+  get(req: GetMedicineRequest): Promise<AppServiceResponse<MedicineDto[]> | Message>;
+  getDosage(
+    req: GetMedicineDosageRequest
+  ): Promise<AppServiceResponse<MedicationDosageResultDto> | Message>;
+}

--- a/core/nutrition_care/application/services/next/medicines/interfaces/index.ts
+++ b/core/nutrition_care/application/services/next/medicines/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from "./IMedicineAppService";


### PR DESCRIPTION
This commit introduces the adapter layer for the `next/medicines` module.

It includes:
- The Persistence DTO for `Medicine`.
- The Infrastructure Mapper to convert between the domain entity and the persistence DTO.
- The Expo and Web repository implementations.
- Database schema updates for both Expo (SQLite) and Web (IndexedDB).
- All necessary index files with aliased exports.