### PR TITLE
feat(test): Add unit tests for the shared bounded context

### DIFF
--- a/tests/core/shared/application/Message.test.ts
+++ b/tests/core/shared/application/Message.test.ts
@@ -1,0 +1,9 @@
+import { Message } from "../../../../core/shared/application/Message";
+
+describe("Message", () => {
+  it("should create a new message with the correct properties", () => {
+    const message = new Message("info", "This is a test message");
+    expect(message.type).toBe("info");
+    expect(message.content).toBe("This is a test message");
+  });
+});

--- a/tests/core/shared/core/Guard.test.ts
+++ b/tests/core/shared/core/Guard.test.ts
@@ -1,0 +1,43 @@
+import { Guard } from "../../../../core/shared/core/Guard";
+
+describe("Guard", () => {
+  describe("againstNullOrUndefined", () => {
+    it("should return succeeded: false for null", () => {
+      const result = Guard.againstNullOrUndefined(null, "test");
+      expect(result.succeeded).toBe(false);
+      expect(result.message).toBe("test is null or undefined");
+    });
+
+    it("should return succeeded: false for undefined", () => {
+      const result = Guard.againstNullOrUndefined(undefined, "test");
+      expect(result.succeeded).toBe(false);
+      expect(result.message).toBe("test is null or undefined");
+    });
+
+    it("should return succeeded: true for a valid value", () => {
+      const result = Guard.againstNullOrUndefined("hello", "test");
+      expect(result.succeeded).toBe(true);
+    });
+  });
+
+  describe("againstNullOrUndefinedBulk", () => {
+    it("should return succeeded: false if one argument is null", () => {
+      const args = [
+        { argument: "hello", argumentName: "arg1" },
+        { argument: null, argumentName: "arg2" },
+      ];
+      const result = Guard.againstNullOrUndefinedBulk(args);
+      expect(result.succeeded).toBe(false);
+      expect(result.message).toBe("arg2 is null or undefined");
+    });
+
+    it("should return succeeded: true if all arguments are valid", () => {
+      const args = [
+        { argument: "hello", argumentName: "arg1" },
+        { argument: 123, argumentName: "arg2" },
+      ];
+      const result = Guard.againstNullOrUndefinedBulk(args);
+      expect(result.succeeded).toBe(true);
+    });
+  });
+});

--- a/tests/core/shared/core/Result.test.ts
+++ b/tests/core/shared/core/Result.test.ts
@@ -1,0 +1,58 @@
+import { Result } from "../../../../core/shared/core/Result";
+
+describe("Result", () => {
+  describe("ok", () => {
+    it("should create a successful result", () => {
+      const result = Result.ok<string>("success");
+      expect(result.isSuccess).toBe(true);
+      expect(result.isFailure).toBe(false);
+      expect(result.val).toBe("success");
+    });
+  });
+
+  describe("fail", () => {
+    it("should create a failed result", () => {
+      const result = Result.fail<string>("error");
+      expect(result.isSuccess).toBe(false);
+      expect(result.isFailure).toBe(true);
+      expect(result.err).toBe("error");
+    });
+  });
+
+  describe("getValue", () => {
+    it("should return the value of a successful result", () => {
+      const result = Result.ok<string>("success");
+      expect(result.val).toBe("success");
+    });
+
+    it("should throw an error for a failed result", () => {
+      const result = Result.fail<string>("error");
+      expect(() => result.val).toThrow();
+    });
+  });
+
+  describe("errorValue", () => {
+    it("should return the error of a failed result", () => {
+      const result = Result.fail<string>("error");
+      expect(result.err).toBe("error");
+    });
+  });
+
+  describe("combine", () => {
+    it("should return a successful result if all results are successful", () => {
+      const results = [Result.ok<string>("one"), Result.ok<string>("two")];
+      const combined = Result.combine(results as any);
+      expect(combined.isSuccess).toBe(true);
+    });
+
+    it("should return a failed result if one result is a failure", () => {
+      const results = [
+        Result.ok<string>("one"),
+        Result.fail<string>("error"),
+      ];
+      const combined = Result.combine(results as any);
+      expect(combined.isFailure).toBe(true);
+      expect(combined.err).toBe("error");
+    });
+  });
+});

--- a/tests/core/shared/domain/common/Entity.test.ts
+++ b/tests/core/shared/domain/common/Entity.test.ts
@@ -1,0 +1,45 @@
+import { Entity } from "../../../../../core/shared/domain/common/Entity";
+import { EntityUniqueID } from "../../../../../core/shared/domain/common/EntityUniqueId";
+
+interface TestProps {
+  foo: string;
+}
+
+class TestEntity extends Entity<TestProps> {
+  private constructor(props: TestProps, id?: EntityUniqueID) {
+    super({props, id: id ? id.toValue(): new EntityUniqueID('test-id').toValue()});
+  }
+
+  public static create(props: TestProps, id?: EntityUniqueID): TestEntity {
+    return new TestEntity(props, id);
+  }
+
+  public validate(): void {
+    // no validation
+  }
+}
+
+describe("Entity", () => {
+  it("should be equal if they have the same id", () => {
+    const id = new EntityUniqueID('test-id');
+    const entity1 = TestEntity.create({ foo: "bar" }, id);
+    const entity2 = TestEntity.create({ foo: "baz" }, id);
+    expect(entity1.equals(entity2)).toBe(true);
+  });
+
+  it("should not be equal if they have different ids", () => {
+    const entity1 = TestEntity.create({ foo: "bar" }, new EntityUniqueID('id-1'));
+    const entity2 = TestEntity.create({ foo: "baz" }, new EntityUniqueID('id-2'));
+    expect(entity1.equals(entity2)).toBe(false);
+  });
+
+  it("should not be equal to null", () => {
+    const entity1 = TestEntity.create({ foo: "bar" });
+    expect(entity1.equals(null as any)).toBe(false);
+  });
+
+  it("should not be equal to undefined", () => {
+    const entity1 = TestEntity.create({ foo: "bar" });
+    expect(entity1.equals(undefined as any)).toBe(false);
+  });
+});

--- a/tests/core/shared/domain/common/EntityUniqueId.test.ts
+++ b/tests/core/shared/domain/common/EntityUniqueId.test.ts
@@ -1,0 +1,13 @@
+import { EntityUniqueID } from "../../../../../core/shared/domain/common/EntityUniqueId";
+
+describe("EntityUniqueId", () => {
+  it("should create a new EntityUniqueId with a string value", () => {
+    const id = new EntityUniqueID("test-id");
+    expect(id.toValue()).toBe("test-id");
+  });
+
+  it("should create a new EntityUniqueId with a number value", () => {
+    const id = new EntityUniqueID(123);
+    expect(id.toValue()).toBe(123);
+  });
+});

--- a/tests/core/shared/domain/common/ValueObject.test.ts
+++ b/tests/core/shared/domain/common/ValueObject.test.ts
@@ -1,0 +1,40 @@
+import { ValueObject } from "../../../../../core/shared/domain/common/ValueObject";
+
+interface TestProps {
+  foo: string;
+  bar: number;
+}
+
+class TestValueObject extends ValueObject<TestProps> {
+  constructor(props: TestProps) {
+    super(props);
+  }
+
+  public validate(props: TestProps): void {
+    // no validation
+  }
+}
+
+describe("ValueObject", () => {
+  it("should be equal if they have the same props", () => {
+    const vo1 = new TestValueObject({ foo: "hello", bar: 123 });
+    const vo2 = new TestValueObject({ foo: "hello", bar: 123 });
+    expect(vo1.equals(vo2)).toBe(true);
+  });
+
+  it("should not be equal if they have different props", () => {
+    const vo1 = new TestValueObject({ foo: "hello", bar: 123 });
+    const vo2 = new TestValueObject({ foo: "world", bar: 456 });
+    expect(vo1.equals(vo2)).toBe(false);
+  });
+
+  it("should not be equal to null", () => {
+    const vo1 = new TestValueObject({ foo: "hello", bar: 123 });
+    expect(vo1.equals(null as any)).toBe(false);
+  });
+
+  it("should not be equal to undefined", () => {
+    const vo1 = new TestValueObject({ foo: "hello", bar: 123 });
+    expect(vo1.equals(undefined as any)).toBe(false);
+  });
+});

--- a/tests/core/shared/domain/shared/valueObjects/BirthDay.test.ts
+++ b/tests/core/shared/domain/shared/valueObjects/BirthDay.test.ts
@@ -1,0 +1,15 @@
+import { Birthday } from "../../../../../../core/shared/domain/shared/valueObjects/BirthDay";
+
+describe("Birthday", () => {
+  it("should create a valid birthday", () => {
+    const birthday = Birthday.create("2000-01-01");
+    expect(birthday.isSuccess).toBe(true);
+    expect(birthday.val.toString()).toBe("2000-01-01");
+  });
+
+  it("should calculate the correct age", () => {
+    const birthday = Birthday.create("2000-01-01").val;
+    const expectedAge = new Date().getFullYear() - 2000;
+    expect(birthday.getAge()).toBe(expectedAge);
+  });
+});

--- a/tests/core/shared/domain/shared/valueObjects/Email.test.ts
+++ b/tests/core/shared/domain/shared/valueObjects/Email.test.ts
@@ -1,0 +1,14 @@
+import { Email } from "../../../../../../core/shared/domain/shared/valueObjects/Email";
+
+describe("Email", () => {
+  it("should create a valid email", () => {
+    const email = Email.create("test@example.com");
+    expect(email.isSuccess).toBe(true);
+    expect(email.val.toString()).toBe("test@example.com");
+  });
+
+  it("should fail to create an invalid email", () => {
+    const email = Email.create("invalid-email");
+    expect(email.isFailure).toBe(true);
+  });
+});

--- a/tests/core/shared/domain/shared/valueObjects/FullName.test.ts
+++ b/tests/core/shared/domain/shared/valueObjects/FullName.test.ts
@@ -1,0 +1,24 @@
+import { FullName } from "../../../../../../core/shared/domain/shared/valueObjects/FullName";
+
+describe("FullName", () => {
+  it("should create a valid full name", () => {
+    const fullName = FullName.create("John Doe");
+    expect(fullName.isSuccess).toBe(true);
+    expect(fullName.val.fullName).toBe("John Doe");
+  });
+
+  it("should return the correct first name", () => {
+    const fullName = FullName.create("John Doe").val;
+    expect(fullName.firstName).toBe("John");
+  });
+
+  it("should return the correct last name", () => {
+    const fullName = FullName.create("John Doe").val;
+    expect(fullName.lastName).toBe("Doe");
+  });
+
+  it("should fail to create an empty full name", () => {
+    const fullName = FullName.create("");
+    expect(fullName.isFailure).toBe(true);
+  });
+});

--- a/tests/core/shared/utils/DateManager.test.ts
+++ b/tests/core/shared/utils/DateManager.test.ts
@@ -1,0 +1,17 @@
+import { DateManager } from "../../../../core/shared/utils/DateManager";
+
+describe("DateManager", () => {
+  it("should format a date correctly", () => {
+    const date = new Date("2023-10-27T10:00:00.000Z");
+    const formatted = DateManager.formatDate(date);
+    expect(formatted).toBe("2023-10-27");
+  });
+
+  it("should format a date and time correctly and be timezone-independent", () => {
+    const date = new Date("2023-10-27T10:00:00.000Z");
+    const formatted = DateManager.dateToDateTimeString(date);
+    // Matches YYYY-MM-DD HH:MM:SS format to avoid timezone issues in tests
+    const dateTimeRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+    expect(formatted).toMatch(dateTimeRegex);
+  });
+});


### PR DESCRIPTION
This commit introduces unit tests for the `shared` bounded context, following the established testing conventions.

- Adds tests for core utilities like `Guard` and `Result`.
- Adds tests for domain primitives such as `Entity`, `EntityUniqueID`, and `ValueObject`.
- Adds tests for various value objects including `Email`, `Birthday`, and `FullName`.
- Adds tests for application and utility services.

All tests pass and provide a solid foundation for ensuring the stability and correctness of the shared components.